### PR TITLE
fix: empty owner for Response to ProposeAttributeRequestItem

### DIFF
--- a/_includes/scenarios/integrate/propose-attribute-to-peer.md
+++ b/_includes/scenarios/integrate/propose-attribute-to-peer.md
@@ -213,7 +213,7 @@ We assume that the Recipient confirms the fittingness of the PersonName proposed
       "accept": true,
       "attribute": {
         "@type": "IdentityAttribute",
-        "owner": "",
+        "owner": "<Address of Recipient>",
         "value": {
           "@type": "PersonName",
           "givenName": "<given name that the Sender proposes to the Recipient>",
@@ -230,7 +230,7 @@ We assume that the Recipient confirms the fittingness of the PersonName proposed
           "accept": true,
           "attribute": {
             "@type": "IdentityAttribute",
-            "owner": "",
+            "owner": "<Address of Recipient>",
             "value": {
               "@type": "EMailAddress",
               "value": "<Recipient's corrected version of the email address>"


### PR DESCRIPTION
When responding to a ProposeAttributeRequestItem, it should not be allowed to respond with an Attribute that contains an empty string as `owner`. This is because that would lead to the creation of an Attribute that has an empty string as owner and not the Recipient.