### PR TITLE
Remove deprecated publisher modules

### DIFF
--- a/_docs_operate/configuration.md
+++ b/_docs_operate/configuration.md
@@ -278,39 +278,6 @@ The HTTP server is the base for the `coreHttpApi` Module. It opens an express HT
 
 Every Module can be enabled or disabled by passing true / false to `enabled`. Read more about the Module by clicking on the <i class="fas fa-fw fa-info-circle"/> icon in each title.
 
-#### amqpPublisher <a href="{% link _docs_operate/modules.md %}#amqppublisher"><i class="fas fa-fw fa-info-circle"/></a> {#amqppublisher}
-
-This module is deprecated in favor of the [Message Broker Publisher](#messagebrokerpublisher) Module.
-{: .notice--danger}
-
-**Sample Configuration:**
-
-```jsonc
-{
-  // ...
-
-  "modules": {
-    "amqpPublisher": {
-      "enabled": false,
-      "url": "amqp://example.com:5672",
-      "exchange": "myExchange"
-    }
-  }
-}
-```
-
-- **enabled** `default: false`
-
-  Enable or disable the AMQP Publisher Module.
-
-- **url** `required`
-
-  The URL of the AMQP server.
-
-- **exchange** `default: ""`
-
-  The name of the AMQP exchange to publish to.
-
 #### autoAcceptPendingRelationships <a href="{% link _docs_operate/modules.md %}#autoacceptpendingrelationships"><i class="fas fa-fw fa-info-circle"/></a> {#autoacceptpendingrelationships}
 
 It is not recommended to use this Module for production scenarios.
@@ -423,9 +390,9 @@ It is not recommended to use this Module for production scenarios.
 
       > the URL must be in the [AMQP url format](https://www.rabbitmq.com/docs/uri-spec)
 
-    - exchange `string` -
+    - exchange `string, default: ""` -
 
-      the name of the exchange to publish to
+      the name of the AMQP exchange to publish to
 
     - timeout `number` -
 

--- a/_docs_operate/configuration.md
+++ b/_docs_operate/configuration.md
@@ -494,44 +494,6 @@ It is not recommended to use this Module for production scenarios.
 
   The interval in seconds at which the sync Module will fetch changes from the Backbone.
 
-#### PubSubPublisher <a href="{% link _docs_operate/modules.md %}#pubsubpublisher"><i class="fas fa-fw fa-info-circle"/></a> {#pubsubpublisher}
-
-This module is deprecated in favor of the [Message Broker Publisher](#messagebrokerpublisher) Module.
-{: .notice--danger}
-
-**Sample Configuration:**
-
-```jsonc
-{
-  // ...
-
-  "modules": {
-    "PubSubPublisher": {
-      "enabled": false,
-      "projectId": "",
-      "topic": "",
-      "keyFile": ""
-    }
-  }
-}
-```
-
-- **enabled** `default: false`
-
-  Enable or disable the PubSub Publisher Module.
-
-- **projectId** `required`
-
-  The project id of the Google Cloud project.
-
-- **topic** `required`
-
-  The name of the PubSub topic to publish to.
-
-- **keyFile** `required`
-
-  The (absolute) path of the key file to authenticate with the Google Cloud project.
-
 #### webhooks <a href="{% link _docs_operate/modules.md %}#webhooks"><i class="fas fa-fw fa-info-circle"/></a> {#webhooks}
 
 **Sample Configuration:**

--- a/_docs_operate/modules.md
+++ b/_docs_operate/modules.md
@@ -29,18 +29,6 @@ Additionally, the Connector defines its own Modules that only make sense in the 
 
 Read more about the Module configuration on the <i class="fas fa-fw fa-cog"/> icon in each title.
 
-### AMQP Publisher <a href="{% link _docs_operate/configuration.md %}#amqppublisher"><i class="fas fa-fw fa-cog"/></a> {#amqppublisher}
-
-This module is deprecated in favor of the [Message Broker Publisher](#messagebrokerpublisher) Module.
-{: .notice--danger}
-
-This Module proxies all [events]({% link _docs_integrate/connector-events.md %}) of the internal event bus of the Connector to an exchange in a configurable AMQP server.
-
-Compared to [webhooks](#webhooks), this gives you the full feature set of a message broker. There are multiple scenarios where this Module outweighs the Webhooks Module. For example:
-
-- You need persistence for the triggered [events]({% link _docs_integrate/connector-events.md %}).
-- You want to integrate enmeshed into an already existing message broker.
-
 ### Auto Accept Pending Relationships <a href="{% link _docs_operate/configuration.md %}#autoacceptpendingrelationships"><i class="fas fa-fw fa-cog"/></a> {#autoacceptpendingrelationships}
 
 It is not recommended to use this Module for production scenarios.
@@ -56,7 +44,7 @@ This Module contains the HTTP API with all enmeshed base functionalities.
 
 ### Message Broker Publisher <a href="{% link _docs_operate/configuration.md %}#messagebrokerpublisher"><i class="fas fa-fw fa-cog"/></a> {#messagebrokerpublisher}
 
-The Message Broker Publisher Module allows you to publish [events]({% link _docs_integrate/connector-events.md %}) to different message brokers. Supported message brokers are: `AMQP`, `PubSub`, `Redis` and `MQTT`.
+The Message Broker Publisher Module allows you to publish [events]({% link _docs_integrate/connector-events.md %}) of the internal event bus of the Connector to different message brokers. Supported message brokers are: `AMQP`, `PubSub`, `Redis` and `MQTT`.
 
 Compared to [webhooks](#webhooks), this gives you the full feature set of these message brokers. There are multiple scenarios where this Module outweighs the Webhooks Module. For example:
 
@@ -69,18 +57,6 @@ The `sync` Module regularly fetches changes from the Backbone (e.g. new Messages
 
 The sync Module and the [sse Module](#sse) are not compatible. The sync Module will be disabled if both are active.
 {: .notice--warning}
-
-### PubSub Publisher <a href="{% link _docs_operate/configuration.md %}#pubsubpublisher"><i class="fas fa-fw fa-cog"/></a> {#pubsubpublisher}
-
-This module is deprecated in favor of the [Message Broker Publisher](#messagebrokerpublisher) Module.
-{: .notice--danger}
-
-This Module proxies all events of the internal event bus of the Connector to a configurable PubSub instance.
-
-Compared to [webhooks](#webhooks), this gives you the full feature set of a message broker. There are multiple scenarios where this Module outweighs the Webhooks Module. For example:
-
-- You need persistence for the triggered [events]({% link _docs_integrate/connector-events.md %}).
-- You want to integrate enmeshed into an already existing message broker.
 
 ### Webhooks <a href="{% link _docs_operate/configuration.md %}#webhooks"><i class="fas fa-fw fa-cog"/></a> {#webhooks}
 


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This PR removes the documentation of the deprecated AMQP and PubSub publisher modules (https://github.com/nmshd/connector/pull/174). Instead, the MessageBroker publisher module can be used.