### PR TITLE
Mention validation of IdentityAttribute `tags` in use cases

### DIFF
--- a/_docs_use-cases/use-case-consumption-check-if-repositoryattribute-can-be-created.md
+++ b/_docs_use-cases/use-case-consumption-check-if-repositoryattribute-can-be-created.md
@@ -55,6 +55,7 @@ If a RepositoryAttribute can be created, this can be achieved by executing the [
 - If the `isSuccess` property of the `result` has the value `true`, the RepositoryAttribute can currently be created.
 - If the `isSuccess` property of the `result` has the value `false`, the RepositoryAttribute cannot currently be created. This may have the following reasons:
   - The provided `content.value.@type` does not match one of the allowed [IdentityAttribute value types]({% link _docs_integrate/attribute-values.md %}#identity-attributes).
+  - Invalid `content.tags` were provided. A tag is invalid if it is neither contained in the [AttributeTagCollection]({% link _docs_integrate/data-model-overview.md %}#attributetagcollection) for the `content.value.@type` nor starts with the custom tag prefix `x+%+` or `X+%+`.
   - There is already an existing [RepositoryAttribute]({% link _docs_integrate/data-model-overview.md %}#localattribute) whose `succeededBy` property is undefined that has the exact same `content.value`.
 
 ## On Failure

--- a/_docs_use-cases/use-case-consumption-create-a-repositoryattribute.md
+++ b/_docs_use-cases/use-case-consumption-create-a-repositoryattribute.md
@@ -56,4 +56,6 @@ This use case is intended to create a RepositoryAttribute, i.e. an unshared [Loc
 
 ## On Failure
 
+- The LocalAttribute cannot be created if the provided `content.value.@type` does not match one of the allowed [IdentityAttribute value types]({% link _docs_integrate/attribute-values.md %}#identity-attributes).
+- The LocalAttribute cannot be created if invalid `content.tags` were specified. A tag is invalid if it is neither contained in the [AttributeTagCollection]({% link _docs_integrate/data-model-overview.md %}#attributetagcollection) for the `content.value.@type` nor starts with the custom tag prefix `x+%+` or `X+%+`.
 - The LocalAttribute cannot be created if there is already an existing RepositoryAttribute whose `succeededBy` property is undefined that has the exact same `content.value`.

--- a/_docs_use-cases/use-case-transport-upload-own-file.md
+++ b/_docs_use-cases/use-case-transport-upload-own-file.md
@@ -69,3 +69,4 @@ In the latter case, the [Token for the File must be created]({% link _docs_use-c
 
 - The parameters are malformed.
 - The file size is too big.
+- Invalid `tags` were provided. A tag is invalid if it is neither contained in the [AttributeTagCollection]({% link _docs_integrate/data-model-overview.md %}#attributetagcollection) for the [IdentityAttribute]({% link _docs_integrate/data-model-overview.md %}#identityattribute) `value.@type` [IdentityFileReference]({% link _docs_integrate/attribute-values.md %}#identityfilereference) nor starts with the custom tag prefix `x+%+` or `X+%+`.


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Since the check if RepositoryAttribute can be created use case has been added (https://github.com/nmshd/documentation/pull/337), we can now mention the IdentityAttribute `tags` validaton in all affected use cases.
