### PR TITLE
Mention removed `GET /api/v2/Attributes/Valid` Connector route

### DIFF
--- a/_docs_integrate/migration-from-v6-to-v7.md
+++ b/_docs_integrate/migration-from-v6-to-v7.md
@@ -55,9 +55,10 @@ The step-by-step instructions can be consulted to start the migration to version
 - Stricter validation of `tags` of [IdentityAttributes]({% link _docs_integrate/data-model-overview.md %}#identityattribute) and [Files]({% link _docs_integrate/data-model-overview.md %}#file) have been added as documented in their description in the data model overview.
   An error with [error code]({% link _docs_integrate/error-codes.md %}) `error.consumption.attributes.invalidTags` will be thrown if an attempt is made to use invalid `tags`.
 
-### Changes to Connector Routes
+### Removed and Changed Connector Routes
 
-- The `onlyValid` parameter was removed from the use cases [Get Attributes]({% link _docs_use-cases/use-case-consumption-get-attributes.md %}), [Get own shared Attributes]({% link _docs_use-cases/use-case-consumption-get-own-shared-attributes.md %}) and [Get peer shared Attributes]({% link _docs_use-cases/use-case-consumption-get-peer-shared-attributes.md %}) as the properties `validFrom` and `validTo` have been removed from the [Attributes]({% link _docs_integrate/data-model-overview.md %}#attributes).
+- The `GET /api/v2/Attributes/Valid` Connector route was removed, because the properties `validFrom` and `validTo` have been removed from the [Attributes]({% link _docs_integrate/data-model-overview.md %}#attributes).
+- For the same reason, the `onlyValid` parameter was removed from the use cases [Get Attributes]({% link _docs_use-cases/use-case-consumption-get-attributes.md %}), [Get own shared Attributes]({% link _docs_use-cases/use-case-consumption-get-own-shared-attributes.md %}) and [Get peer shared Attributes]({% link _docs_use-cases/use-case-consumption-get-peer-shared-attributes.md %}).
   Accordingly, it was removed from the associated Connector routes as well.
 
 ## Runtime-Specific Breaking Changes

--- a/_docs_integrate/migration-from-v6-to-v7.md
+++ b/_docs_integrate/migration-from-v6-to-v7.md
@@ -57,7 +57,7 @@ The step-by-step instructions can be consulted to start the migration to version
 
 ### Removed and Changed Connector Routes
 
-- The `GET /api/v2/Attributes/Valid` Connector route was removed, because the properties `validFrom` and `validTo` have been removed from the [Attributes]({% link _docs_integrate/data-model-overview.md %}#attributes).
+- The `GET /api/v2/Attributes/Valid` Connector route and its underlying [use case]({% link _docs_integrate/use-cases.md %}) for getting valid [Attributes]({% link _docs_integrate/data-model-overview.md %}#attributes) were removed, because the properties `validFrom` and `validTo` have been removed from the Attributes.
 - For the same reason, the `onlyValid` parameter was removed from the use cases [Get Attributes]({% link _docs_use-cases/use-case-consumption-get-attributes.md %}), [Get own shared Attributes]({% link _docs_use-cases/use-case-consumption-get-own-shared-attributes.md %}) and [Get peer shared Attributes]({% link _docs_use-cases/use-case-consumption-get-peer-shared-attributes.md %}).
   Accordingly, it was removed from the associated Connector routes as well.
 


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The Connector route `GET /api/v2/Attributes/Valid` and its underlying `getValidAttributes` use case have been removed with version 7 of the Connector (and Runtime).