### PR TITLE
Specify requirements for valid API keys

### DIFF
--- a/_docs_integrate/examples/example.config.json
+++ b/_docs_integrate/examples/example.config.json
@@ -14,7 +14,7 @@
                 "apiKey": {
                     "keys": {
                         "<an-api-key-id>": {
-                            "key": "<define-an-apiKey => https://enmeshed.eu/operate/configuration#httpserver>"
+                            "key": "<define-a-valid-API-key-with-at-least-30-chars => https://enmeshed.eu/operate/configuration#apikey>"
                         }
                     }
                 }

--- a/_docs_integrate/migration-from-v6-to-v7.md
+++ b/_docs_integrate/migration-from-v6-to-v7.md
@@ -85,7 +85,7 @@ import { ApiKeyAuthenticator, ConnectorClient } from "@nmshd/connector-sdk";
 
 const connectorClient = ConnectorClient.create({
   baseUrl: "https://<INSERT_YOUR_CONNECTOR_DOMAIN_HERE>",
-  authenticator: new ApiKeyAuthenticator("<INSERT_YOUR_API_KEY_HERE>")
+  authenticator: new ApiKeyAuthenticator("<INSERT_YOUR_API_KEY_WITH_AT_LEAST_30_CHARS_HERE>")
 });
 ```
 

--- a/_docs_operate/configuration.md
+++ b/_docs_operate/configuration.md
@@ -74,7 +74,7 @@ You want to configure the following values:
         "apiKey": {
           "keys": {
             "default": {
-              "key": "an-api-key"
+              "key": "a-valid-API-key-with-at-least-30-chars"
             }
           }
         }
@@ -86,7 +86,7 @@ You want to configure the following values:
 
 - The first value can be configured using the variable `infrastructure:httpServer:enabled="true"`. Note that the value is represented as a string in the environment variable and the Connector will rewrite it to its boolean representation.
 - The second value can be configured using the variable `infrastructure:httpServer:port="8080"`. Note that the value is represented as a string in the environment variable and the Connector will rewrite it to its number representation.
-- The third value can be configured using the variable `infrastructure:httpServer:authentication:apiKey:keys:default:key="an-api-key"`.
+- The third value can be configured using the variable `infrastructure:httpServer:authentication:apiKey:keys:default:key="a-valid-API-key-with-at-least-30-chars"`.
 
 ## Configuration options
 
@@ -235,7 +235,7 @@ The HTTP server is the base for the `coreHttpApi` Module. It opens an express HT
         "apiKey": {
           "keys": {
             "default": {
-              "key": "an-api-key"
+              "key": "a-valid-API-key-with-at-least-30-chars"
             }
           }
         }
@@ -312,7 +312,7 @@ If multiple authentication methods are configured, the authentication methods wi
   "apiKey": {
     "keys": {
       "default": {
-        "key": "an-api-key"
+        "key": "a-valid-API-key-with-at-least-30-chars"
       }
     }
   }

--- a/_docs_operate/configuration.md
+++ b/_docs_operate/configuration.md
@@ -338,7 +338,7 @@ The `apiKey` authentication method is used to authenticate requests using an API
 
   - **key** `required`
 
-    The actual API key that is used to authenticate the request. This key must be kept secret and should not be shared with anyone.
+    The actual API key that is used to authenticate the request. This key must be kept secret and should not be shared with anyone. A valid API key must be at least 30 characters long and contain at least 2 digits, 2 uppercase letters, 2 lowercase letters and 1 special character out of ``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``.
 
   - **description** `optional`
 

--- a/_docs_operate/setup-with-docker-compose.md
+++ b/_docs_operate/setup-with-docker-compose.md
@@ -141,7 +141,7 @@ To use the api platform hosted on the Connector you need to make the following c
            "apiKey": {
              "keys": {
                "<an-api-key-id>": {
-                 "key": "<an-api-key>"
+                 "key": "<a-valid-API-key-with-at-least-30-chars>"
                }
              }
            }


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough.
- [x] I labeled the PR.
- [] I self-reviewed the PR.

# Description

A valid API key must be at least 30 characters long and contain at least 2 digits, 2 uppercase letters, 2 lowercase letters and 1 special character out of ``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``.